### PR TITLE
:bug: 修复Button组件htmlType为type

### DIFF
--- a/src/components/button/index.js
+++ b/src/components/button/index.js
@@ -70,8 +70,8 @@ class Button extends React.PureComponent {
 					...{
 						...others,
 						href: href || undefined,
-						target: href ? target : undefined,
-						htmlType: href ? undefined : htmlType
+						type: href ? undefined : htmlType,
+						target: href ? target : undefined
 					}
 				}
 			>


### PR DESCRIPTION
`button`标签只支持`type`属性，但是由于封装过后`type`用来干别的事情了，用`htmlType`来代替原生`button`上的`type`，忘了在使用的时候把`htmlType`转成`type`了